### PR TITLE
Add env var: `GOOGLE_KEY_JSON_FILENAME`

### DIFF
--- a/api/server/services/Endpoints/google/initialize.js
+++ b/api/server/services/Endpoints/google/initialize.js
@@ -7,6 +7,7 @@ const { GoogleClient } = require('~/app');
 const initializeClient = async ({ req, res, endpointOption, overrideModel, optionsOnly }) => {
   const {
     GOOGLE_KEY,
+    GOOGLE_KEY_JSON_FILENAME,
     GOOGLE_REVERSE_PROXY,
     GOOGLE_AUTH_HEADER,
     PROXY,
@@ -20,9 +21,10 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
     userKey = await getUserKey({ userId: req.user.id, name: EModelEndpoint.google });
   }
 
+  const googleKeyJsonFilename = GOOGLE_KEY_JSON_FILENAME ?? '~/data/auth.json';
   let serviceKey = {};
   try {
-    serviceKey = require('~/data/auth.json');
+    serviceKey = require(googleKeyJsonFilename);
   } catch (e) {
     // Do nothing
   }


### PR DESCRIPTION
Adding a new env var so we can put the json file used for Google/Vertex auth in a different place besides the hardcoded `~/data/auth.json`.

## Usage

Got it working locally with:
- `GOOGLE_KEY=service_key`
- `GOOGLE_KEY_JSON_FILENAME=/etc/secrets/google-auth.json`
- And a bind mount in the docker-compose.yml mounting the json file in to that `/etc/secrets` path

![image](https://github.com/user-attachments/assets/b92db4cc-d3f4-4d11-98d5-9454f77b0b74)
