### PR TITLE
Fix librechat.img.yaml not being included in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 data-node
 meili_data*
 librechat*
+!librechat.img.yaml
 Dockerfile*
 docs
 


### PR DESCRIPTION
## Summary
- Fixed issue where `librechat.img.yaml` was being excluded from Docker build context
- Added `\!librechat.img.yaml` exception to `.dockerignore` after the `librechat*` pattern

## Problem
The `librechat*` pattern in `.dockerignore` was preventing the `librechat.img.yaml` configuration file from being included in the Docker build context, causing it to be missing from the built image.

## Solution  
Added a specific exception `\!librechat.img.yaml` after the `librechat*` pattern to ensure this configuration file is included in the Docker build. The exception comes after the exclusion pattern because the last matching rule wins in `.dockerignore` files.

## Test plan
- [ ] Build Docker image and verify `librechat.img.yaml` is present
- [ ] Confirm other `librechat*` files are still properly excluded